### PR TITLE
Fix dev_t.R examples

### DIFF
--- a/R/dev_t.R
+++ b/R/dev_t.R
@@ -60,7 +60,7 @@
 #'         with the document.id and creation & update time stamps
 #'
 #' @examples
-#'
+#'  \dontrun{
 #'  # connect to hublot
 #'  credentials <- hublot::get_credentials(
 #'    Sys.getenv("HUB3_URL"),
@@ -78,6 +78,7 @@
 #'    credentials = credentials,
 #'    nbrows=10
 #'    )
+#'  }
 #'
 #' @export
 #'

--- a/R/dev_t.R
+++ b/R/dev_t.R
@@ -171,7 +171,7 @@ get_warehouse_table <- function(table_name, credentials, data_filter=list(), nbr
 #' @return returns a dataframe containing the data warehouse table content
 #'
 #' @examples
-#'
+#' \dontrun{
 #'  clessnhub::login(
 #'    Sys.getenv("HUB_USERNAME"),
 #'    Sys.getenv("HUB_PASSWORD"),
@@ -193,6 +193,7 @@ get_warehouse_table <- function(table_name, credentials, data_filter=list(), nbr
 #'    max_pages = -1,
 #'    hub_conf = hub_config
 #'    )
+#'  }
 #'
 #' @export
 #'

--- a/R/dev_t.R
+++ b/R/dev_t.R
@@ -527,6 +527,7 @@ commit_mart_row <- function(table_name, key, row = list(), mode = "refresh", cre
 #'         attribute as well as a document.id and creation & update time stamps
 #'
 #' @examples
+#' \dontrun{
 #'  # connect to hublot
 #'  credentials <- hublot::get_credentials(
 #'    Sys.getenv("HUB3_URL"),
@@ -541,7 +542,7 @@ commit_mart_row <- function(table_name, key, row = list(), mode = "refresh", cre
 #'   key_column = 'key',
 #'   mode = 'add',
 #'   credentials = credentials)
-#'
+#' }
 #'
 #' @export
 #'

--- a/R/dev_t.R
+++ b/R/dev_t.R
@@ -325,6 +325,7 @@ get_hub2_table <- function(table_name, data_filter=NULL, max_pages=-1, hub_conf)
 #'         attribute as well as a document.id and creation & update time stamps
 #'
 #' @examples
+#' \dontrun{
 #'  # connect to hublot
 #'  credentials <- hublot::get_credentials(
 #'    Sys.getenv("HUB3_URL"),
@@ -344,6 +345,7 @@ get_hub2_table <- function(table_name, data_filter=NULL, max_pages=-1, hub_conf)
 #'    data_filter = list(),
 #'    credentials = credentials,
 #'    nbrows=10)
+#'  }
 #'
 #' @export
 #'

--- a/R/dev_t.R
+++ b/R/dev_t.R
@@ -454,7 +454,7 @@ get_mart_table <- function(table_name, credentials, data_filter=list(), nbrows=0
 #'         attribute as well as a document.id and creation & update time stamps
 #'
 #' @examples
-#'
+#' \dontrun{
 #' # connect to hublot
 #' credentials <- hublot::get_credentials(
 #'   Sys.getenv("HUB3_URL"),
@@ -469,6 +469,7 @@ get_mart_table <- function(table_name, credentials, data_filter=list(), nbrows=0
 #'   row = list(week_num=21, count=6, political_party="QS"),
 #'   mode = "refresh",
 #'   credentials = credentials)
+#' }
 #'
 #' @export
 #'

--- a/man/commit_mart_row.Rd
+++ b/man/commit_mart_row.Rd
@@ -38,7 +38,7 @@ commit_mart_row allows the programmer to write a row in a data
 table of a CLESSN data mart.
 }
 \examples{
-
+\dontrun{
 # connect to hublot
 credentials <- hublot::get_credentials(
   Sys.getenv("HUB3_URL"),
@@ -53,5 +53,6 @@ clessnverse::commit_mart_row(
   row = list(week_num=21, count=6, political_party="QS"),
   mode = "refresh",
   credentials = credentials)
+}
 
 }

--- a/man/commit_mart_table.Rd
+++ b/man/commit_mart_table.Rd
@@ -34,6 +34,7 @@ commit_mart_row allows the programmer to write a tabe as a
 CLESSN data mart.
 }
 \examples{
+\dontrun{
  # connect to hublot
  credentials <- hublot::get_credentials(
    Sys.getenv("HUB3_URL"),
@@ -48,6 +49,6 @@ CLESSN data mart.
   key_column = 'key',
   mode = 'add',
   credentials = credentials)
-
+}
 
 }

--- a/man/get_hub2_table.Rd
+++ b/man/get_hub2_table.Rd
@@ -28,7 +28,7 @@ table from the CLESSN hub2 data warehouse.
 ** WARNING hub2 will be decommissionned by end of 2022 **
 }
 \examples{
-
+\dontrun{
  clessnhub::login(
    Sys.getenv("HUB_USERNAME"),
    Sys.getenv("HUB_PASSWORD"),
@@ -50,5 +50,6 @@ table from the CLESSN hub2 data warehouse.
    max_pages = -1,
    hub_conf = hub_config
    )
+ }
 
 }

--- a/man/get_mart_table.Rd
+++ b/man/get_mart_table.Rd
@@ -30,6 +30,7 @@ get_mart_table allows the programmer to retrieve a data
 table from a CLESSN data mart.
 }
 \examples{
+\dontrun{
  # connect to hublot
  credentials <- hublot::get_credentials(
    Sys.getenv("HUB3_URL"),
@@ -49,5 +50,6 @@ table from a CLESSN data mart.
    data_filter = list(),
    credentials = credentials,
    nbrows=10)
+ }
 
 }

--- a/man/get_warehouse_table.Rd
+++ b/man/get_warehouse_table.Rd
@@ -31,7 +31,7 @@ get_warehouse_table allows the programmer to retrieve a data
 table from the CLESSN data warehouse named hublot.
 }
 \examples{
-
+ \dontrun{
  # connect to hublot
  credentials <- hublot::get_credentials(
    Sys.getenv("HUB3_URL"),
@@ -49,5 +49,6 @@ table from the CLESSN data warehouse named hublot.
    credentials = credentials,
    nbrows=10
    )
+ }
 
 }


### PR DESCRIPTION
Fixes #36

@PatrickPoncet @olichose123 Est-ce que l'un de vous deux voudrait bien jeter un coup d'oeil à ces modifications s.v.p.?

J'ai placé les exemples des fonctions de transformations dans `\dontrun{}` afin qu'elles ne soient pas roulées à chaque fois qu'on utilise `devtools::check()`.

Sans ce, les exemples sont roulées et, vu que ça ne peut pas aller chercher mes credentials, `devtools::check()` retourne des messages d'erreurs.

Si ça passe, merci de merger le pull request :)

Faites-moi signe s'il y a une autre solution plus intéressante.