### PR TITLE
Replace non-ASCII characters with unicode escapes in `translate_text()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: clessnverse
 Title: Package for Data Domestication, Analysis, and Visualization
-Version: 0.5.1.9000
+Version: 0.5.2
 Authors@R: c(
     person("William", "Poirier", , "william.poirier.1@ulaval.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3274-1351")),

--- a/R/dev_t.R
+++ b/R/dev_t.R
@@ -985,11 +985,11 @@ translate_text <- function (text, engine = "azure", source_lang = NA, target_lan
     # There atr characters that need to be escaped (or even removed) in order for the translator to
     # be able to take them
     text <- stringr::str_replace_all(text, "\\'", "\\\\'")
-    text <- stringr::str_replace_all(text, "\\«", "")
-    text <- stringr::str_replace_all(text, "\\»", "")
-    text <- stringr::str_replace_all(text, "\\«", "")
-    text <- stringr::str_replace_all(text, "\\»", "")
-    text <- stringr::str_replace_all(text, "\\’", "\\\\'")
+    text <- stringr::str_replace_all(text, "\\\u00ab", "")
+    text <- stringr::str_replace_all(text, "\\\u00bb", "")
+    text <- stringr::str_replace_all(text, "\\\u00ab", "")
+    text <- stringr::str_replace_all(text, "\\\u00bb", "")
+    text <- stringr::str_replace_all(text, "\\\u2019", "\\\\'")
 
     key <- Sys.getenv("AZURE_TRANSLATE_KEY")
 


### PR DESCRIPTION
# Issue

The function `translate_text()` contained non-ASCII characters. To ensure the package's portability (a.k.a. so it can be used accross OS), they should be in their unicode escapes equivalent.

For example, `"ç"` becomes `"\u00e7"`.

# Solution

In this PR, all non-ASCII characters in `translate_text()` were converted to their unicode escapes.

To make sure the function's behavior wouldn't change, tests were created **(but not intergrated in the package)** as shown below.

```
# Initial code
remove_char_for_translator <- function(text) {
  text <- stringr::str_replace_all(text, "\\'", "\\\\'")
  text <- stringr::str_replace_all(text, "\\«", "")
  text <- stringr::str_replace_all(text, "\\»", "")
  text <- stringr::str_replace_all(text, "\\«", "")
  text <- stringr::str_replace_all(text, "\\»", "")
  text <- stringr::str_replace_all(text, "\\’", "\\\\'")
  
  return(text)
}

# Unicode escapes
remove_char_for_translator <- function(text) {
  text <- stringr::str_replace_all(text, "\\'", "\\\\'")
  text <- stringr::str_replace_all(text, "\\\u00ab", "")
  text <- stringr::str_replace_all(text, "\\\u00bb", "")
  text <- stringr::str_replace_all(text, "\\\u00ab", "")
  text <- stringr::str_replace_all(text, "\\\u00bb", "")
  text <- stringr::str_replace_all(text, "\\\u2019", "\\\\'")
  
  return(text)
}

test_that("removing characters for translator works", {
  expect_equal(remove_char_for_translator("\\' Hello World.\\'"), "\\\\' Hello World.\\\\'")
  expect_equal(remove_char_for_translator("\\« Hello World. \\»"), "\\ Hello World. \\")
  expect_equal(remove_char_for_translator("\\’ Hello World.\\’"), "\\\\' Hello World.\\\\'")
  }
)
```

Tests have all passed.

Closes #102 #66

# Suggestions

- [ ] To intergrate automated unit tests, create internal function for this code chunk
- [ ] Delete duplicate rows of code