### PR TITLE
Specify package dependency name and repo in github

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,8 +41,8 @@ Imports:
     tidyr,
     tidytext,
     XML
-Remotes: clessn/hublotr,
-    clessn/clessn-hub-r
+Remotes: hublot=github::clessn/hublotr,
+    clessnhub=github::clessn/clessn-hub-r
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
# Issue
In the GitHub Action R CMD Check, package dependencies for `clessnhub` and `hublot` [couldn't download properly](https://github.com/clessn/clessnverse/actions/runs/4642963233/jobs/8217284074#step:4:133) as their repo name didn't correspont to the package name.

```
For github:: dependencies pkgdepends assumes that the package name is the same as 
the name of the repository. If this does not hold, then you need to specify the package 
name explicitly, using a <package>= prefix. E.g. pins=rstudio/pins-r. If you specify both 
the package source type and the package name, the package name comes first: 
pins=github::rstudio/pins-r.
```
([source](https://r-lib.github.io/pkgdepends/reference/pkg_refs.html#package-names))

# Solution

Adapted `DESCRIPTION` accordingly:
```
clessnhub=github::clessn/clessn-hub-r
hublot=github::clessn/hublotr
```

PS: First green checkmark  ✅  for clessnverse's R CMD Check!! 🥳