### PR TITLE
Remove package source type for dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: clessnverse
 Title: Package for Data Domestication, Analysis, and Visualization
-Version: 0.5.2
+Version: 0.5.3
 Authors@R: c(
     person("William", "Poirier", , "william.poirier.1@ulaval.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3274-1351")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,8 +41,8 @@ Imports:
     tidyr,
     tidytext,
     XML
-Remotes: hublot=github::clessn/hublotr,
-    clessnhub=github::clessn/clessn-hub-r
+Remotes: hublot=clessn/hublotr,
+    clessnhub=clessn/clessn-hub-r
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
This will allow downloading dependencies from GitHub for packages with different names than their repo.

Fixes #115 